### PR TITLE
Remove console.log from production

### DIFF
--- a/cartridges/int_poq_checkout_bridge_sfra/cartridge/templates/default/checkout/orderTotalSummary.isml
+++ b/cartridges/int_poq_checkout_bridge_sfra/cartridge/templates/default/checkout/orderTotalSummary.isml
@@ -80,8 +80,6 @@
 </script>
 
 <script type="text/javascript">
-    console.log(poqOrderDetails);
-
     PoqWebCheckout.send('paymentcompleted', {
         order: poqOrderDetails
     });


### PR DESCRIPTION
I think clients will appreciate that we don't add console.logs to their production websites.

We could potentially wrap it in an `if (environment === development)` if we have access to some environment string.