### PR TITLE
Fix multiple calls to PaymentCompleted event in JsBridge

### DIFF
--- a/cartridges/int_poq_checkout_bridge_sfra/cartridge/templates/default/checkout/orderTotalSummary.isml
+++ b/cartridges/int_poq_checkout_bridge_sfra/cartridge/templates/default/checkout/orderTotalSummary.isml
@@ -80,11 +80,11 @@
 </script>
 
 <script type="text/javascript">
-    console.log(poqOrderDetails);
-
-    PoqWebCheckout.send('paymentcompleted', {
-        order: poqOrderDetails
-    });
+    if (document.location.pathname.endsWith("Order-Confirm")) {
+        PoqWebCheckout.send('paymentcompleted', {
+            order: poqOrderDetails
+        });
+    }
 
     document.addEventListener("DOMContentLoaded", function(event) {
         var continueBtn = document.getElementsByClassName("order-confirmation-continue-shopping")[0];


### PR DESCRIPTION
Poq Checkout Bridge cartridge sends PaymentCompleted event multiple times. Add location check to limit event firing to one.